### PR TITLE
Add Ruby 3.2 and Rust 1.68.0.  Update checkout action versions.

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
       - name: rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,14 +10,15 @@ jobs:
   build:
     name: ruby
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ["2.7", "3.0", "3.1"]
-        rust: ["1.51.0", "1.54.0", "1.60.0", "1.62.1", "1.65.0"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        rust: ["1.61.0", "1.62.1", "1.65.0", "1.68.0"]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -29,7 +30,7 @@ jobs:
         with:
           rust-version: ${{ matrix.rust }}
       - name: Cache gems
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('.tool-versions') }}-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
Runs green on my fork.  Required me to update the minimum Rust version because of changes in the dependencies.